### PR TITLE
Rejig repository

### DIFF
--- a/lib/code_time/session_repository.rb
+++ b/lib/code_time/session_repository.rb
@@ -7,20 +7,27 @@ class SessionRepository
   end
 
   def all
-    sessions = adapter.all
-    build_session_collection(sessions)
+    build_session_collection(all_sessions)
   end
 
   def store(session)
     adapter.save(session)
   end
 
-  def find_by_length(seconds)
-    sessions = adapter.find_by_length(seconds)
+  def find_by_length(duration)
+    sessions = find_sessions_by_length(duration)
     build_session_collection(sessions)
   end
 
   private
+  
+  def all_sessions
+    adapter.all
+  end
+
+  def find_sessions_by_length
+    adapter.find_by_length(duration)
+  end
 
   def build_session_collection(sessions)
     sessions.map do |session_attributes|

--- a/lib/code_time/session_repository.rb
+++ b/lib/code_time/session_repository.rb
@@ -8,10 +8,7 @@ class SessionRepository
 
   def all
     sessions = adapter.all
-    return [] if sessions.empty?
-    sessions.map do |session_attributes|
-      session_factory.make(session_attributes)
-    end
+    build_session_collection(sessions)
   end
 
   def store(session)
@@ -20,8 +17,18 @@ class SessionRepository
 
   def find_by_length(seconds)
     sessions = adapter.find_by_length(seconds)
+    build_session_collection(sessions)
+  end
+
+  private
+
+  def build_session_collection(sessions)
     sessions.map do |session_attributes|
-      session_factory.make(session_attributes)
+      build_session_with_attributes(session_attributes)
     end
+  end
+
+  def build_session_with_attributes(attributes)
+    session_factory.make(attributes)
   end
 end

--- a/lib/code_time/session_repository.rb
+++ b/lib/code_time/session_repository.rb
@@ -1,12 +1,17 @@
 class SessionRepository
-  attr_reader :adapter
+  attr_reader :adapter, :session_factory
 
-  def initialize(adapter)
+  def initialize(adapter, session_factory)
     @adapter = adapter
+    @session_factory = session_factory
   end
 
   def all
-    adapter.all
+    sessions = adapter.all
+    return [] if sessions.empty?
+    sessions.map do |session_attributes|
+      session_factory.make(session_attributes)
+    end
   end
 
   def store(session)
@@ -14,6 +19,9 @@ class SessionRepository
   end
 
   def find_by_length(seconds)
-    adapter.find_by_length(seconds)
+    sessions = adapter.find_by_length(seconds)
+    sessions.map do |session_attributes|
+      session_factory.make(session_attributes)
+    end
   end
 end

--- a/lib/code_time/session_repository.rb
+++ b/lib/code_time/session_repository.rb
@@ -25,7 +25,7 @@ class SessionRepository
     adapter.all
   end
 
-  def find_sessions_by_length
+  def find_sessions_by_length(duration)
     adapter.find_by_length(duration)
   end
 

--- a/session_repository_spec.rb
+++ b/session_repository_spec.rb
@@ -42,40 +42,47 @@ end
 
 describe 'SessionRepository' do
   describe '#all' do
-    let(:adapter) { AdapterDouble.new }
-    let(:session_factory) { SessionFactoryDouble.new }
+    let(:adapter) { double('adapter') }
+    let(:session_factory) { double('session_factory') }
     let(:session_repo) { SessionRepository.new(adapter, session_factory) }
 
     it 'returns an empty array if there are no sessions stored' do
+      expect(adapter).to receive(:all) { [] }
+
       expect(session_repo.all).to eq([])
     end
 
     it 'returns an array containing one session if one session is stored' do
-      session_one = { id: 1, length: 5, description: 'Ruby is good', created_at: Time.now.to_s }
+      session_one = double('session')
 
+      expect(session_factory).to receive(:make)
       expect(adapter).to receive(:all) { [session_one] }
       
-      expect(session_repo.all.last.length).to eq(5)
+      expect(session_repo.all.size).to eq(1)
     end
 
     it 'returns an array containing many sessions if many sessions are stored' do
-      session_one = { id: 1, length: 5, description: 'Ruby is good', created_at: Time.now.to_s }
-      session_two = { id: 2, length: 10, description: 'Ruby is bad', created_at: Time.now.to_s }
+      session_one = double('session')
+      session_two = double('session')
 
+      expect(session_factory).to receive(:make).twice
       expect(adapter).to receive(:all) { [session_one, session_two] }
       
-      expect(session_repo.all.last.length).to eq(10)
+      expect(session_repo.all.size).to eq(2)
     end
   end
 
   describe '#store' do
-    let(:adapter) { AdapterDouble.new }
-    let(:session_factory) { SessionFactoryDouble.new }
+    let(:adapter) { double('adapter') }
+    let(:session_factory) { double('session_factory') }
     let(:session_repo) { SessionRepository.new(adapter, session_factory) }
 
     it 'stores a single session' do
       session_one = { length: 5, description: 'Ruby is good', created_at: Time.now.to_s }
 
+      allow(session_factory).to receive(:make) { double('session') }
+      allow(adapter).to receive(:all) { [{ id: 1 }.merge(session_one)] }
+      expect(adapter).to receive(:save).with(session_one) 
       session_repo.store(session_one)
 
       expect(session_repo.all.count).to eq(1)
@@ -85,6 +92,10 @@ describe 'SessionRepository' do
       session_one = { length: 5, description: 'Ruby is good', created_at: Time.now.to_s }
       session_two = { length: 1, description: 'TDD is good', created_at: Time.now.to_s }
 
+      allow(session_factory).to receive(:make).twice { double('session') }
+      allow(adapter).to receive(:all) { [{ id: 1 }.merge(session_one), { id: 2 }.merge(session_two)] }
+      expect(adapter).to receive(:save).with(session_one)
+      expect(adapter).to receive(:save).with(session_two)
       session_repo.store(session_one)
       session_repo.store(session_two)
 
@@ -93,8 +104,8 @@ describe 'SessionRepository' do
   end
 
   describe '#find_by_length' do
-    let(:adapter) { AdapterDouble.new }
-    let(:session_factory) { SessionFactoryDouble.new }
+    let(:adapter) { double('adapter') }
+    let(:session_factory) { double('session_factory') }
     let(:session_repo) { SessionRepository.new(adapter, session_factory) }
 
     it 'returns an empty array if no session matches' do
@@ -107,6 +118,10 @@ describe 'SessionRepository' do
         { id: 2, length: 20, description: 'TDD is good', created_at: Time.now.to_s },
       ]
 
+      session_one = double('session')
+      expect(session_one).to receive(:description) { all_sessions.first[:description] }
+      allow(session_factory).to receive(:make) { session_one }
+      expect(adapter).to receive(:find_by_length).with(10) { all_sessions.first }
       allow(adapter).to receive(:sessions).and_return(all_sessions)
      
       expect(session_repo.find_by_length(10).first.description).to eq('Ruby is good')

--- a/session_repository_spec.rb
+++ b/session_repository_spec.rb
@@ -18,6 +18,26 @@ class AdapterDouble
   end
 end
 
+class AltAdapterDouble
+  def sessions
+    @sessions ||= []
+  end
+
+  def save(session_data)
+    @id ||= 1
+    sessions << { id: @id }.merge(session_data)
+    @id += 1
+  end
+
+  def all
+    sessions
+  end
+
+  def find_by_length(seconds)
+    sessions.reject { |session| session.fetch(:length) != seconds }
+  end
+end
+
 describe 'SessionRepository' do
   describe '#all' do
     it 'returns an empty array if there are no sessions stored' do
@@ -47,51 +67,61 @@ describe 'SessionRepository' do
 
   describe '#store' do
     it 'stores a single session' do
-      session_repo = SessionRepository.new(AdapterDouble.new)
-      session = double('session')
+      session_repo = SessionRepository.new(AltAdapterDouble.new)
+      session_data = { length: 5, description: 'Ruby is good', created_at: Time.now.to_s }
 
-      session_repo.store(session)
+      session_repo.store(session_data)
 
-      expect(session_repo.all.first).to eq(session)
+      expect(session_repo.all.first).to eq({ id: 1 }.merge(session_data))
+    end
+
+    it 'stores a second session to a non-empty repository' do
+      session_repo = SessionRepository.new(AltAdapterDouble.new)
+      session_data_one = { length: 5, description: 'Ruby is good', created_at: Time.now.to_s }
+      session_data_two = { length: 1, description: 'TDD is good', created_at: Time.now.to_s }
+
+      session_repo.store(session_data_one)
+      session_repo.store(session_data_two)
+
+      results_collection = [{ id: 1 }.merge(session_data_one), 
+                            { id: 2 }.merge(session_data_two)]
+
+      expect(session_repo.all).to match_array(results_collection)
     end
   end
 
   describe '#find_by_length' do
     it 'returns an empty array if no session matches' do
-      session_repo = SessionRepository.new(AdapterDouble.new)
+      session_repo = SessionRepository.new(AltAdapterDouble.new)
 
       expect(session_repo.find_by_length(10)).to eq([])
     end
 
     it 'returns a single session in an array if one session matches' do
-      session_repo = SessionRepository.new(AdapterDouble.new)
-      matching_session = double('session')
-      non_matching_session = double('session')
-      allow(matching_session).to receive(:length) { 10 }
-      allow(non_matching_session).to receive(:length) { 20 }
+      session_repo = SessionRepository.new(AltAdapterDouble.new)
+      matching_session = { length: 10, description: 'Ruby is good', created_at: Time.now.to_s }
+      non_matching_session = { length: 20, description: 'TDD is good', created_at: Time.now.to_s }
+
       session_repo.store(matching_session)
       session_repo.store(non_matching_session)
-
-      expect(session_repo.find_by_length(10)).to eq([matching_session])
+     
+      expect(session_repo.find_by_length(10)).to eq([{ id: 1 }.merge(matching_session)])
     end
 
     it 'returns many sessions in an array if many sessions match' do
-      session_repo = SessionRepository.new(AdapterDouble.new)
-      matching_session_one = double('session')
-      non_matching_session_one = double('session')
-      matching_session_two = double('session')
-      non_matching_session_two = double('session')
+      session_repo = SessionRepository.new(AltAdapterDouble.new)
+      matching_session_one = { length: 10, description: 'Ruby is good', created_at: Time.now.to_s }
+      non_matching_session_one = { length: 20, description: 'TDD is good', created_at: Time.now.to_s }
+      matching_session_two = { length: 10, description: 'Ruby is bad', created_at: Time.now.to_s }
+      non_matching_session_two = { length: 20, description: 'TDD is bad', created_at: Time.now.to_s }
 
-      allow(matching_session_one).to receive(:length) { 10 }
-      allow(non_matching_session_one).to receive(:length) { 20 }
-      allow(matching_session_two).to receive(:length) { 10 }
-      allow(non_matching_session_two).to receive(:length) { 40 }
       session_repo.store(matching_session_one)
       session_repo.store(non_matching_session_one)
       session_repo.store(matching_session_two)
       session_repo.store(non_matching_session_two)
-
-      expect(session_repo.find_by_length(10)).to match_array([matching_session_one, matching_session_two])
+     
+     # Actually, we want to return a Session object here made by the SessionFactory
+      expect(session_repo.find_by_length(10)).to eq([{ id: 1 }.merge(matching_session_one), { id: 3 }.merge(matching_session_two)])
     end
   end
 end

--- a/session_repository_spec.rb
+++ b/session_repository_spec.rb
@@ -14,7 +14,27 @@ class AdapterDouble
   end
 
   def find_by_length(seconds)
-    sessions.reject { |session| session.length != seconds }
+    sessions.reject { |session| session[:length] != seconds }
+  end
+end
+
+class SessionDouble
+  attr_reader :length, :description, :created_at
+
+  def initialize(length:, description:, created_at:)
+    @length = length
+    @description = description
+    @created_at = created_at
+  end
+
+  def attributes
+    { length: length, description: description, created_at: created_at }
+  end
+end
+
+class SessionFactoryDouble
+  def make(attributes)
+    SessionDouble.new(length: attributes[:length], description: attributes[:description], created_at: attributes[:created_at])
   end
 end
 
@@ -41,87 +61,90 @@ end
 describe 'SessionRepository' do
   describe '#all' do
     it 'returns an empty array if there are no sessions stored' do
-      session_repo = SessionRepository.new(AdapterDouble.new)
+      session_repo = SessionRepository.new(AltAdapterDouble.new, SessionFactoryDouble.new)
 
       expect(session_repo.all).to eq([])
     end
 
     it 'returns an array containing one session if one session is stored' do
-      session_repo = SessionRepository.new(AdapterDouble.new)
-      session = double('session')
-      session_repo.adapter.save(session)
+      adapter = AltAdapterDouble.new
+      session_repo = SessionRepository.new(adapter, SessionFactoryDouble.new)
+
+      session_one = { id: 1, length: 5, description: 'Ruby is good', created_at: Time.now.to_s }
+
+      expect(adapter).to receive(:all) { [session_one] }
       
-      expect(session_repo.all).to eq([session])
+      expect(session_repo.all.last.length).to eq(5)
     end
 
     it 'returns an array containing many sessions if many sessions are stored' do
-      session_repo = SessionRepository.new(AdapterDouble.new)
-      session_one = double('session')
-      session_two = double('session')
-      session_repo.adapter.save(session_one)
-      session_repo.adapter.save(session_two)
+      adapter = AltAdapterDouble.new
+      session_repo = SessionRepository.new(adapter, SessionFactoryDouble.new)
+
+      session_one = { id: 1, length: 5, description: 'Ruby is good', created_at: Time.now.to_s }
+      session_two = { id: 2, length: 10, description: 'Ruby is bad', created_at: Time.now.to_s }
+
+      expect(adapter).to receive(:all) { [session_one, session_two] }
       
-      expect(session_repo.all).to match_array([session_one, session_two])
+      expect(session_repo.all.last.length).to eq(10)
     end
   end
 
   describe '#store' do
     it 'stores a single session' do
-      session_repo = SessionRepository.new(AltAdapterDouble.new)
-      session_data = { length: 5, description: 'Ruby is good', created_at: Time.now.to_s }
+      session_repo = SessionRepository.new(AltAdapterDouble.new, SessionFactoryDouble.new)
+      session_one = { length: 5, description: 'Ruby is good', created_at: Time.now.to_s }
 
-      session_repo.store(session_data)
+      session_repo.store(session_one)
 
-      expect(session_repo.all.first).to eq({ id: 1 }.merge(session_data))
+      expect(session_repo.all.count).to eq(1)
     end
 
     it 'stores a second session to a non-empty repository' do
-      session_repo = SessionRepository.new(AltAdapterDouble.new)
-      session_data_one = { length: 5, description: 'Ruby is good', created_at: Time.now.to_s }
-      session_data_two = { length: 1, description: 'TDD is good', created_at: Time.now.to_s }
+      session_repo = SessionRepository.new(AltAdapterDouble.new, SessionFactoryDouble.new)
+      session_one = { length: 5, description: 'Ruby is good', created_at: Time.now.to_s }
+      session_two = { length: 1, description: 'TDD is good', created_at: Time.now.to_s }
 
-      session_repo.store(session_data_one)
-      session_repo.store(session_data_two)
+      session_repo.store(session_one)
+      session_repo.store(session_two)
 
-      results_collection = [{ id: 1 }.merge(session_data_one), 
-                            { id: 2 }.merge(session_data_two)]
-
-      expect(session_repo.all).to match_array(results_collection)
+      expect(session_repo.all.count).to eq(2)
     end
   end
 
   describe '#find_by_length' do
     it 'returns an empty array if no session matches' do
-      session_repo = SessionRepository.new(AltAdapterDouble.new)
+      session_repo = SessionRepository.new(AltAdapterDouble.new, SessionFactoryDouble.new)
 
       expect(session_repo.find_by_length(10)).to eq([])
     end
 
     it 'returns a single session in an array if one session matches' do
-      session_repo = SessionRepository.new(AltAdapterDouble.new)
-      matching_session = { length: 10, description: 'Ruby is good', created_at: Time.now.to_s }
-      non_matching_session = { length: 20, description: 'TDD is good', created_at: Time.now.to_s }
+      adapter = AltAdapterDouble.new
+      session_repo = SessionRepository.new(adapter, SessionFactoryDouble.new)
+      all_sessions = [
+        { id: 1, length: 10, description: 'Ruby is good', created_at: Time.now.to_s },
+        { id: 2, length: 20, description: 'TDD is good', created_at: Time.now.to_s },
+      ]
 
-      session_repo.store(matching_session)
-      session_repo.store(non_matching_session)
+      allow(adapter).to receive(:sessions).and_return(all_sessions)
      
-      expect(session_repo.find_by_length(10)).to eq([{ id: 1 }.merge(matching_session)])
+      expect(session_repo.find_by_length(10).first.description).to eq('Ruby is good')
     end
 
     it 'returns many sessions in an array if many sessions match' do
-      session_repo = SessionRepository.new(AltAdapterDouble.new)
-      matching_session_one = { length: 10, description: 'Ruby is good', created_at: Time.now.to_s }
-      non_matching_session_one = { length: 20, description: 'TDD is good', created_at: Time.now.to_s }
-      matching_session_two = { length: 10, description: 'Ruby is bad', created_at: Time.now.to_s }
-      non_matching_session_two = { length: 20, description: 'TDD is bad', created_at: Time.now.to_s }
+      adapter = AltAdapterDouble.new
+      session_repo = SessionRepository.new(adapter, SessionFactoryDouble.new)
+      all_sessions = [
+        { id: 1, length: 10, description: 'Ruby is good', created_at: Time.now.to_s },
+        { id: 2, length: 20, description: 'TDD is good', created_at: Time.now.to_s },
+        { id: 3, length: 10, description: 'Ruby is bad', created_at: Time.now.to_s },
+        { id: 4, length: 20, description: 'TDD is bad', created_at: Time.now.to_s }
+      ]
 
-      session_repo.store(matching_session_one)
-      session_repo.store(non_matching_session_one)
-      session_repo.store(matching_session_two)
-      session_repo.store(non_matching_session_two)
+      allow(adapter).to receive(:sessions).and_return(all_sessions)
      
-     # Actually, we want to return a Session object here made by the SessionFactory
-      expect(session_repo.find_by_length(10)).to eq([{ id: 1 }.merge(matching_session_one), { id: 3 }.merge(matching_session_two)])
+      expect(session_repo.find_by_length(10).map(&:description)).to match_array(['Ruby is good', 'Ruby is bad'])
     end
   end
 end

--- a/session_repository_spec.rb
+++ b/session_repository_spec.rb
@@ -42,16 +42,15 @@ end
 
 describe 'SessionRepository' do
   describe '#all' do
-    it 'returns an empty array if there are no sessions stored' do
-      session_repo = SessionRepository.new(AdapterDouble.new, SessionFactoryDouble.new)
+    let(:adapter) { AdapterDouble.new }
+    let(:session_factory) { SessionFactoryDouble.new }
+    let(:session_repo) { SessionRepository.new(adapter, session_factory) }
 
+    it 'returns an empty array if there are no sessions stored' do
       expect(session_repo.all).to eq([])
     end
 
     it 'returns an array containing one session if one session is stored' do
-      adapter = AdapterDouble.new
-      session_repo = SessionRepository.new(adapter, SessionFactoryDouble.new)
-
       session_one = { id: 1, length: 5, description: 'Ruby is good', created_at: Time.now.to_s }
 
       expect(adapter).to receive(:all) { [session_one] }
@@ -60,9 +59,6 @@ describe 'SessionRepository' do
     end
 
     it 'returns an array containing many sessions if many sessions are stored' do
-      adapter = AdapterDouble.new
-      session_repo = SessionRepository.new(adapter, SessionFactoryDouble.new)
-
       session_one = { id: 1, length: 5, description: 'Ruby is good', created_at: Time.now.to_s }
       session_two = { id: 2, length: 10, description: 'Ruby is bad', created_at: Time.now.to_s }
 
@@ -73,8 +69,11 @@ describe 'SessionRepository' do
   end
 
   describe '#store' do
+    let(:adapter) { AdapterDouble.new }
+    let(:session_factory) { SessionFactoryDouble.new }
+    let(:session_repo) { SessionRepository.new(adapter, session_factory) }
+
     it 'stores a single session' do
-      session_repo = SessionRepository.new(AdapterDouble.new, SessionFactoryDouble.new)
       session_one = { length: 5, description: 'Ruby is good', created_at: Time.now.to_s }
 
       session_repo.store(session_one)
@@ -83,7 +82,6 @@ describe 'SessionRepository' do
     end
 
     it 'stores a second session to a non-empty repository' do
-      session_repo = SessionRepository.new(AdapterDouble.new, SessionFactoryDouble.new)
       session_one = { length: 5, description: 'Ruby is good', created_at: Time.now.to_s }
       session_two = { length: 1, description: 'TDD is good', created_at: Time.now.to_s }
 
@@ -95,15 +93,15 @@ describe 'SessionRepository' do
   end
 
   describe '#find_by_length' do
-    it 'returns an empty array if no session matches' do
-      session_repo = SessionRepository.new(AdapterDouble.new, SessionFactoryDouble.new)
+    let(:adapter) { AdapterDouble.new }
+    let(:session_factory) { SessionFactoryDouble.new }
+    let(:session_repo) { SessionRepository.new(adapter, session_factory) }
 
+    it 'returns an empty array if no session matches' do
       expect(session_repo.find_by_length(10)).to eq([])
     end
 
     it 'returns a single session in an array if one session matches' do
-      adapter = AdapterDouble.new
-      session_repo = SessionRepository.new(adapter, SessionFactoryDouble.new)
       all_sessions = [
         { id: 1, length: 10, description: 'Ruby is good', created_at: Time.now.to_s },
         { id: 2, length: 20, description: 'TDD is good', created_at: Time.now.to_s },
@@ -115,8 +113,6 @@ describe 'SessionRepository' do
     end
 
     it 'returns many sessions in an array if many sessions match' do
-      adapter = AdapterDouble.new
-      session_repo = SessionRepository.new(adapter, SessionFactoryDouble.new)
       all_sessions = [
         { id: 1, length: 10, description: 'Ruby is good', created_at: Time.now.to_s },
         { id: 2, length: 20, description: 'TDD is good', created_at: Time.now.to_s },

--- a/session_repository_spec.rb
+++ b/session_repository_spec.rb
@@ -1,23 +1,5 @@
 require './lib/code_time/session_repository'
 
-class AdapterDouble
-  def sessions
-    @sessions ||= []
-  end
-
-  def save(session)
-    sessions << session
-  end
-
-  def all
-    sessions
-  end
-
-  def find_by_length(seconds)
-    sessions.reject { |session| session[:length] != seconds }
-  end
-end
-
 class SessionDouble
   attr_reader :length, :description, :created_at
 

--- a/session_repository_spec.rb
+++ b/session_repository_spec.rb
@@ -20,7 +20,7 @@ class SessionFactoryDouble
   end
 end
 
-class AltAdapterDouble
+class AdapterDouble
   def sessions
     @sessions ||= []
   end
@@ -43,13 +43,13 @@ end
 describe 'SessionRepository' do
   describe '#all' do
     it 'returns an empty array if there are no sessions stored' do
-      session_repo = SessionRepository.new(AltAdapterDouble.new, SessionFactoryDouble.new)
+      session_repo = SessionRepository.new(AdapterDouble.new, SessionFactoryDouble.new)
 
       expect(session_repo.all).to eq([])
     end
 
     it 'returns an array containing one session if one session is stored' do
-      adapter = AltAdapterDouble.new
+      adapter = AdapterDouble.new
       session_repo = SessionRepository.new(adapter, SessionFactoryDouble.new)
 
       session_one = { id: 1, length: 5, description: 'Ruby is good', created_at: Time.now.to_s }
@@ -60,7 +60,7 @@ describe 'SessionRepository' do
     end
 
     it 'returns an array containing many sessions if many sessions are stored' do
-      adapter = AltAdapterDouble.new
+      adapter = AdapterDouble.new
       session_repo = SessionRepository.new(adapter, SessionFactoryDouble.new)
 
       session_one = { id: 1, length: 5, description: 'Ruby is good', created_at: Time.now.to_s }
@@ -74,7 +74,7 @@ describe 'SessionRepository' do
 
   describe '#store' do
     it 'stores a single session' do
-      session_repo = SessionRepository.new(AltAdapterDouble.new, SessionFactoryDouble.new)
+      session_repo = SessionRepository.new(AdapterDouble.new, SessionFactoryDouble.new)
       session_one = { length: 5, description: 'Ruby is good', created_at: Time.now.to_s }
 
       session_repo.store(session_one)
@@ -83,7 +83,7 @@ describe 'SessionRepository' do
     end
 
     it 'stores a second session to a non-empty repository' do
-      session_repo = SessionRepository.new(AltAdapterDouble.new, SessionFactoryDouble.new)
+      session_repo = SessionRepository.new(AdapterDouble.new, SessionFactoryDouble.new)
       session_one = { length: 5, description: 'Ruby is good', created_at: Time.now.to_s }
       session_two = { length: 1, description: 'TDD is good', created_at: Time.now.to_s }
 
@@ -96,13 +96,13 @@ describe 'SessionRepository' do
 
   describe '#find_by_length' do
     it 'returns an empty array if no session matches' do
-      session_repo = SessionRepository.new(AltAdapterDouble.new, SessionFactoryDouble.new)
+      session_repo = SessionRepository.new(AdapterDouble.new, SessionFactoryDouble.new)
 
       expect(session_repo.find_by_length(10)).to eq([])
     end
 
     it 'returns a single session in an array if one session matches' do
-      adapter = AltAdapterDouble.new
+      adapter = AdapterDouble.new
       session_repo = SessionRepository.new(adapter, SessionFactoryDouble.new)
       all_sessions = [
         { id: 1, length: 10, description: 'Ruby is good', created_at: Time.now.to_s },
@@ -115,7 +115,7 @@ describe 'SessionRepository' do
     end
 
     it 'returns many sessions in an array if many sessions match' do
-      adapter = AltAdapterDouble.new
+      adapter = AdapterDouble.new
       session_repo = SessionRepository.new(adapter, SessionFactoryDouble.new)
       all_sessions = [
         { id: 1, length: 10, description: 'Ruby is good', created_at: Time.now.to_s },


### PR DESCRIPTION
Refactor from using 'real' doubles to stubbing out all methods on a generic double.

Tidy up SessionRepository class by bringing everything up to a similar level of abstraction inside public methods.